### PR TITLE
Update run.sh - disabled wine error messages

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+export WINEDEBUG=-all
 cp src/$1.asm lib 
 cd lib 
 wine aml.exe /c /Zd /coff $1.asm 


### PR DESCRIPTION
Hello, 

I added `export WINEDEBUG=-all` to disable noisy Wine debug/error messages. 

Cheers, 

Alex